### PR TITLE
disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In this tutorial, you will:
 
 Ready? Let's go!
 
-👉 [Step 0: Setup](setup)
+👉 [Step 0: Setup](setup.md)
 
 [sdk-js]: https://github.com/KILTprotocol/sdk-js
 [cmy-channel]: https://riot.im/app/#/room/#kilt-general:matrix.org

--- a/attestation.md
+++ b/attestation.md
@@ -85,9 +85,7 @@ attestation.store(attester).then(data => {
 }).catch(e => {
   console.log(e)
 }).finally(() => {
-  Kilt.BlockchainApiConnection.getCached().then(blockchain => {
-    blockchain.api.disconnect()
-  })
+  Kilt.default.disconnect()
 })
 ```
 

--- a/verification.md
+++ b/verification.md
@@ -42,9 +42,7 @@ Kilt.default.connect('wss://full-nodes.kilt.io:9944')
 attestedClaim.verify().then(isValid => {
   console.log('isValid: ', isValid)
 }).finally(() => {
-  Kilt.BlockchainApiConnection.getCached().then(blockchain => {
-    blockchain.api.disconnect()
-  })
+  Kilt.default.disconnect()
 })
 ```
 


### PR DESCRIPTION
## fixes KILTProtocol/ticket#282

- link inside the readme was a 404 if queried from GitHub
- use new disconnect API

## How to test:

Exec `python -m http.server` inside the repository and go through the workshop.

## Checklist:

- [X] I have verified that the code works
- [X] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [X] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [X] I have documented the changes (where applicable)
