### PR TITLE
doc: remove missed `await` from identity generation call.

### DIFF
--- a/08-verification-right.md
+++ b/08-verification-right.md
@@ -73,7 +73,7 @@ async function main() {
   const nonce = '<nonce>'
 
   // <claimerMnemonic> = claimer mnemonic generated in the Identity step
-  const claimer = await Kilt.Identity.buildFromMnemonic('<claimerMnemonic>')
+  const claimer = Kilt.Identity.buildFromMnemonic('<claimerMnemonic>')
   // sign the nonce as the claimer with the claimer's private key
   const signedNonce = claimer.signStr(nonce)
 


### PR DESCRIPTION
While going through the workshop again I noticed I forgot to remove one `await` from the example code. This PR fixes that.
